### PR TITLE
Introduce context logger

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -29,70 +29,71 @@ func (s *ServerEndpoint) Start() error {
 	for {
 		sess, err := listener.Accept(context.Background())
 		if err != nil {
-			klog.ErrorS(err, "Encounter error when accept connection.")
-			return err
+			klog.ErrorS(err, "Encounter error when accept a connection.")
+		} else {
+			logger := klog.NewKlogr().WithValues("Remote-Addr", sess.RemoteAddr())
+			ctx := klog.NewContext(context.TODO(), logger)
+			logger.Info("Received a new connect request.")
+			go s.establishTunnel(ctx, &sess)
 		}
-		klog.Info("Received a new connect request", "client endpoint", sess.RemoteAddr().String())
-		go s.establishTunnel(&sess)
 	}
 }
 
-func (s *ServerEndpoint) establishTunnel(sess *quic.Session) {
-	remoteAddr := (*sess).RemoteAddr().String()
-	klog.InfoS("Starting establish a new tunnel", "client endpoint", remoteAddr)
+func (s *ServerEndpoint) establishTunnel(ctx context.Context, sess *quic.Session) {
+	logger := klog.FromContext(ctx)
+	logger.Info("Starting establish a new tunnel.")
 	stream, err := (*sess).AcceptStream(context.Background())
 	if err != nil {
-		klog.ErrorS(err, "Failed to accept stream", "client endpoint", remoteAddr)
+		logger.Error(err, "Failed to accept stream.")
 		return
 	}
 	defer func() {
 		stream.Close()
-		klog.InfoS("Tunnel closed", "client endpoint", remoteAddr)
+		logger.Info("Tunnel closed")
 	}()
-	conn, err := s.handshake(&stream)
+	conn, err := s.handshake(logger, &stream)
 	if err != nil {
 		return
 	}
 	defer conn.Close()
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go s.serverToClient(&conn, &stream, &wg)
-	go s.clientToServer(&conn, &stream, &wg)
-	klog.InfoS("Tunnel established", "client endpoint", remoteAddr)
+	go s.serverToClient(logger, &conn, &stream, &wg)
+	go s.clientToServer(logger, &conn, &stream, &wg)
+	logger.Info("Tunnel established")
 	wg.Wait()
 }
 
-func (s *ServerEndpoint) handshake(stream *quic.Stream) (net.Conn, error) {
-	klog.Info("Starting handshake")
+func (s *ServerEndpoint) handshake(logger klog.Logger, stream *quic.Stream) (net.Conn, error) {
+	logger.Info("Starting handshake")
 	hsh := handshake.NewHandshakeHelper([]byte{constants.HandshakeSuccess}, constants.AckMsgLength)
-	_, err := io.CopyN(&hsh, *stream, constants.TokenLength)
-	if err != nil {
-		klog.ErrorS(err, "Can not receive token")
+	if _, err := io.CopyN(&hsh, *stream, constants.TokenLength); err != nil {
+		logger.Error(err, "Can not receive token")
 		return nil, err
 	}
-	klog.InfoS("starting connect to server app", "server app", hsh.ReceiveData)
+	logger = logger.WithValues("Server-App-Addr", hsh.ReceiveData)
+	logger.Info("starting connect to server app")
 	sockets := strings.Split(hsh.ReceiveData, ":")
 	conn, err := net.Dial(strings.ToLower(sockets[0]), strings.Join(sockets[1:], ":"))
 	if err != nil {
-		klog.ErrorS(err, "Failed to dial server app", "server address", hsh.ReceiveData)
+		logger.Error(err, "Failed to dial server app")
 		hsh.SendData = []byte{constants.HandshakeFailure}
 		_, err = io.Copy(*stream, &hsh)
 		if err != nil {
-			klog.ErrorS(err, "Failed to dial server app", "server address", hsh.ReceiveData)
+			logger.Error(err, "Failed to dial server app")
 		}
 		return nil, err
 	}
-	klog.Info("Server app connect successful")
-	_, err = io.CopyN(*stream, &hsh, constants.AckMsgLength)
-	if err != nil {
-		klog.ErrorS(err, "Faied to send ack info", hsh.SendData)
+	logger.Info("Server app connect successful")
+	if _, err = io.CopyN(*stream, &hsh, constants.AckMsgLength); err != nil {
+		logger.Error(err, "Faied to send ack info", hsh.SendData)
 		return nil, err
 	}
-	klog.Info("Handshake successful")
+	logger.Info("Handshake successful")
 	return conn, nil
 }
 
-func (s *ServerEndpoint) clientToServer(server *net.Conn, client *quic.Stream, wg *sync.WaitGroup) {
+func (s *ServerEndpoint) clientToServer(logger klog.Logger, server *net.Conn, client *quic.Stream, wg *sync.WaitGroup) {
 	defer func() {
 		wg.Done()
 		(*client).Close()
@@ -100,11 +101,11 @@ func (s *ServerEndpoint) clientToServer(server *net.Conn, client *quic.Stream, w
 	}()
 	_, err := io.Copy(*server, *client)
 	if err != nil {
-		klog.ErrorS(err, "Can not forward packet from client to server")
+		logger.Error(err, "Can not forward packet from client to server")
 	}
 }
 
-func (s *ServerEndpoint) serverToClient(server *net.Conn, client *quic.Stream, wg *sync.WaitGroup) {
+func (s *ServerEndpoint) serverToClient(logger klog.Logger, server *net.Conn, client *quic.Stream, wg *sync.WaitGroup) {
 	defer func() {
 		wg.Done()
 		(*client).Close()
@@ -112,6 +113,6 @@ func (s *ServerEndpoint) serverToClient(server *net.Conn, client *quic.Stream, w
 	}()
 	_, err := io.Copy(*client, *server)
 	if err != nil {
-		klog.ErrorS(err, "Can not forward packet from server to client")
+		logger.Error(err, "Can not forward packet from server to client")
 	}
 }


### PR DESCRIPTION
`klog` support to bind a logger to context and set values and name
for the logger in advance. Now, we introduce this mechanism in order
to we can trace the lifecycle of a tunnel conveniently.