### PR TITLE
Implement token source plugin and token parser plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Start up server side endpoint
 Start up client side endpoint
 
 ```
-./quictun-client --listen-on tcp:127.0.0.1:6500 --server-endpoint 172.18.31.36:7500 --token tcp:172.18.30.117:22 --insecure-skip-verify True
+./quictun-client --listen-on tcp:127.0.0.1:6500 --server-endpoint 172.18.31.36:7500 --token-source tcp:172.18.30.117:22 --insecure-skip-verify True
 ```
 
 **Note:** The value specified by `--token` used to tell `quictun-server` the application address that the client want to access.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -3,5 +3,6 @@ package constants
 const TokenLength = 512
 const AckMsgLength = 1
 
-const HandshakeFailure = 0x00
 const HandshakeSuccess = 0x01
+const ParserTokenError = 0x02
+const CannotConnServer = 0x03

--- a/pkg/token/cleartext_token_parser.go
+++ b/pkg/token/cleartext_token_parser.go
@@ -1,0 +1,28 @@
+package token
+
+import (
+	"encoding/base64"
+	"strings"
+)
+
+type cleartextTokerParser struct {
+	enctype string
+}
+
+func (t cleartextTokerParser) ParseToken(token string) (string, error) {
+	switch strings.ToLower(t.enctype) {
+	case "base64":
+		socket, err := base64.StdEncoding.DecodeString(token)
+		if err != nil {
+			return "", err
+		} else {
+			return string(socket), nil
+		}
+	default:
+		return token, nil
+	}
+}
+
+func NewCleartextTokenParser(key string) cleartextTokerParser {
+	return cleartextTokerParser{enctype: key}
+}

--- a/pkg/token/file_token_source.go
+++ b/pkg/token/file_token_source.go
@@ -1,0 +1,33 @@
+package token
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"strings"
+)
+
+type fileTokenSourcePlugin struct {
+	filePath string
+}
+
+func (t fileTokenSourcePlugin) GetToken(addr string) (string, error) {
+	ipAddr := strings.Split(addr, ":")[0]
+	file, err := os.Open(t.filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, ipAddr) {
+			return strings.Split(line, " ")[1], nil
+		}
+	}
+	return "", errors.New("Don't find valid token.")
+}
+
+func NewFileTokenSourcePlugin(tokenSource string) fileTokenSourcePlugin {
+	return fileTokenSourcePlugin{filePath: tokenSource}
+}

--- a/pkg/token/fixed_token_source.go
+++ b/pkg/token/fixed_token_source.go
@@ -1,0 +1,13 @@
+package token
+
+type fixedTokenSourcePlugin struct {
+	token string
+}
+
+func (t fixedTokenSourcePlugin) GetToken(addr string) (string, error) {
+	return t.token, nil
+}
+
+func NewFixedTokenPlugin(tokenSource string) fixedTokenSourcePlugin {
+	return fixedTokenSourcePlugin{token: tokenSource}
+}

--- a/pkg/token/interface.go
+++ b/pkg/token/interface.go
@@ -1,0 +1,9 @@
+package token
+
+type TokenSourcePlugin interface {
+	GetToken(addr string) (string, error)
+}
+
+type TokenParsePlugin interface {
+	ParseToken(token string) (string, error)
+}


### PR DESCRIPTION
The token source plugin used to provide token in client endpoint.
Client endpoint use the token to handshake with server endpoint.
Server endpoint will use the token parser to parse and verify the
token and get server application socket address from the token.